### PR TITLE
State name conflict

### DIFF
--- a/Editor/UmlGeneration/Service/TextGeneration/TextGenerator.cs
+++ b/Editor/UmlGeneration/Service/TextGeneration/TextGenerator.cs
@@ -178,7 +178,7 @@ namespace Maze.StateFoundry.Editor
 
         static string FindFullName(Type type, HashSet<string> fullNames)
         {
-            return fullNames.FirstOrDefault(fullName => fullName.EndsWith(type.Name));
+            return fullNames.FirstOrDefault(fullName => fullName.EndsWith($"_{type.Name}"));
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Changes
Fixes a bug in text generation where names fully contained within other names (e.g., `Created` vs. `NotCreated`) were incorrectly recognized as the same. Adds stricter checks to correctly distinguish such cases.

## Issues
- Fixes #12 