### PR TITLE
Improve Generic Naming in Interface

### DIFF
--- a/Editor/UmlGeneration/Service/GraphGeneration.cs
+++ b/Editor/UmlGeneration/Service/GraphGeneration.cs
@@ -40,7 +40,7 @@ namespace Maze.StateFoundry.Editor
             m_block.Send(new ScriptImported());
         }
 
-        void OnCheckIfBlock(CheckIfBlock ev)
+        void OnCheckIfBlock(CheckIfBlock trigger)
         {
             m_finder.FindBlocks();
 
@@ -58,13 +58,13 @@ namespace Maze.StateFoundry.Editor
             m_block.Send(new ScriptIsBlock());
         }
 
-        void OnAnalyzeHierarchy(AnalyzeHierarchy ev)
+        void OnAnalyzeHierarchy(AnalyzeHierarchy trigger)
         {
             m_analizer.BuildTree();
             m_block.Send(new HierarchyAnalyzed());
         }
 
-        void OnGenerateText(GenerateText ev)
+        void OnGenerateText(GenerateText trigger)
         {
             m_textGenerator.GenerateText();
 
@@ -77,7 +77,7 @@ namespace Maze.StateFoundry.Editor
             m_block.Send(new TextGenerated());
         }
 
-        void OnPrintUml(PrintUml ev)
+        void OnPrintUml(PrintUml trigger)
         {
             m_printer.Print();
             m_block.Send(new UmlPrinted());

--- a/Runtime/Creation/StateData.cs
+++ b/Runtime/Creation/StateData.cs
@@ -34,9 +34,9 @@ namespace Maze.StateFoundry
             Parent = parent;
         }
 
-        public void AddTransition(Type ev, StateData destination)
+        public void AddTransition(Type trigger, StateData destination)
         {
-            m_transitions[ev] = destination;
+            m_transitions[trigger] = destination;
         }
 
         public void AddChild(StateData child)

--- a/Runtime/Execution/StatechartEvents.cs
+++ b/Runtime/Execution/StatechartEvents.cs
@@ -22,10 +22,10 @@ namespace Maze.StateFoundry
             UnsubscribeToEvents();
         }
 
-        public StateData Send<TEvent>(TEvent ev) where TEvent : struct, ITrigger
+        public StateData Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger
         {
             StateData currentData = m_pool.CurrentData;
-            return SendRecurse(currentData, ev);
+            return SendRecurse(currentData, trigger);
         }
 
         public void Listen<T>(Action<T> callback)
@@ -41,7 +41,7 @@ namespace Maze.StateFoundry
             }
         }
 
-        StateData SendRecurse<TEvent>(StateData data, TEvent ev) where TEvent : struct, ITrigger
+        StateData SendRecurse<TTrigger>(StateData data, TTrigger trigger) where TTrigger : struct, ITrigger
         {
             if (data == null)
             {
@@ -59,10 +59,10 @@ namespace Maze.StateFoundry
                 }
 
                 Type[] genericArgs = iface.GetGenericArguments();
-                Type evType = genericArgs[0];
+                Type triggerType = genericArgs[0];
                 Type targetType = genericArgs[1];
 
-                if (evType != typeof(TEvent))
+                if (triggerType != typeof(TTrigger))
                 {
                     continue;
                 }
@@ -72,14 +72,14 @@ namespace Maze.StateFoundry
                     throw new ArgumentException($"Type {targetType} is not registered");
                 }
 
-                Type intType = typeof(IGet<,>).MakeGenericType(typeof(TEvent), targetType);
+                Type intType = typeof(IGet<,>).MakeGenericType(typeof(TTrigger), targetType);
                 MethodInfo method = stateType.GetInterfaceMap(intType).TargetMethods.FirstOrDefault(m => m.Name.Contains("Get"));
-                method?.Invoke(data.State, new object[] { ev });
+                method?.Invoke(data.State, new object[] { trigger });
 
                 return instance;
             }
 
-            return SendRecurse(data.Parent, ev);
+            return SendRecurse(data.Parent, trigger);
         }
 
         void SubscribeToEvents()

--- a/Runtime/Execution/StatechartRunner.cs
+++ b/Runtime/Execution/StatechartRunner.cs
@@ -24,10 +24,10 @@ namespace Maze.StateFoundry
             m_pool.Dispose();
         }
 
-        public void Send<TEvent>(TEvent ev) where TEvent : struct, ITrigger
+        public void Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger
         {
-            LogEventSent<TEvent>();
-            StateData newData = m_events.Send(ev);
+            LogEventSent<TTrigger>();
+            StateData newData = m_events.Send(trigger);
 
             if (newData == null)
             {
@@ -38,11 +38,11 @@ namespace Maze.StateFoundry
             m_pool.SetCurrentState(newData);
         }
 
-        public void Listen<TEvent>(Action<TEvent> callback) where TEvent : struct, ITrigger
+        public void Listen<TTrigger>(Action<TTrigger> callback) where TTrigger : struct, ITrigger
         {
-            m_events.Listen<TEvent>(output =>
+            m_events.Listen<TTrigger>(output =>
             {
-                LogEventReceived<TEvent>();
+                LogEventReceived<TTrigger>();
                 callback?.Invoke(output);
             });
         }
@@ -63,16 +63,16 @@ namespace Maze.StateFoundry
             }
         }
 
-        void OnSend(ITrigger ev)
+        void OnSend(ITrigger trigger)
         {
             MethodInfo method = GetType().GetMethod(nameof(Send));
-            MethodInfo genericMethod = method?.MakeGenericMethod(ev.GetType());
-            genericMethod?.Invoke(this, new object[] { ev });
+            MethodInfo genericMethod = method?.MakeGenericMethod(trigger.GetType());
+            genericMethod?.Invoke(this, new object[] { trigger });
         }
 
-        void LogEventSent<TEvent>() where TEvent : struct, ITrigger
+        void LogEventSent<TTrigger>() where TTrigger : struct, ITrigger
         {
-            Debug.Log($"<color=yellow>[S]|{m_statechartType.Name}|: {typeof(TEvent).Name}</color>");
+            Debug.Log($"<color=yellow>[S]|{m_statechartType.Name}|: {typeof(TTrigger).Name}</color>");
         }
 
         static void LogTransition(StateData oldData, StateData newData)
@@ -80,9 +80,9 @@ namespace Maze.StateFoundry
             Debug.Log($"<color=cyan>[T]: |{oldData}| => |{newData}|</color>");
         }
 
-        void LogEventReceived<TEvent>() where TEvent : struct, ITrigger
+        void LogEventReceived<TTrigger>() where TTrigger : struct, ITrigger
         {
-            Debug.Log($"<color=magenta>[R]|{m_statechartType.Name}|: {typeof(TEvent).Name}</color>");
+            Debug.Log($"<color=magenta>[R]|{m_statechartType.Name}|: {typeof(TTrigger).Name}</color>");
         }
     }
 }

--- a/Runtime/Model/StateGraph.cs
+++ b/Runtime/Model/StateGraph.cs
@@ -88,10 +88,10 @@ namespace Maze.StateFoundry
 
                 foreach (Type iface in getInterfaces)
                 {
-                    Type ev = iface.GetGenericArguments()[0];
+                    Type trigger = iface.GetGenericArguments()[0];
                     Type destination = iface.GetGenericArguments()[1];
                     BuildMetaGraphRecursive(destination, visited);
-                    visited[state].AddDirectTransition(ev, visited[destination]);
+                    visited[state].AddDirectTransition(trigger, visited[destination]);
                 }
             }
         }

--- a/Runtime/Model/StateMeta.cs
+++ b/Runtime/Model/StateMeta.cs
@@ -38,14 +38,14 @@ namespace Maze.StateFoundry
             m_children.Add(child);
         }
 
-        public void AddTransition(Type ev, StateMeta destination)
+        public void AddTransition(Type trigger, StateMeta destination)
         {
-            m_transitions[ev] = destination;
+            m_transitions[trigger] = destination;
         }
 
-        public void AddDirectTransition(Type ev, StateMeta destination)
+        public void AddDirectTransition(Type trigger, StateMeta destination)
         {
-            m_directTransition[ev] = destination;
+            m_directTransition[trigger] = destination;
         }
 
         public void AddCaption(string note)

--- a/Runtime/Public/Interfaces/IGet.cs
+++ b/Runtime/Public/Interfaces/IGet.cs
@@ -1,8 +1,8 @@
 ﻿namespace Maze.StateFoundry
 {
-    public interface IGet<in TEvent, TState> where TEvent : struct, ITrigger where TState : State, new()
+    public interface IGet<in TTrigger, TNextState> where TTrigger : struct, ITrigger where TNextState : State, new()
     {
-        void Get(TEvent ev)
+        void Get(TTrigger trigger)
         {
         }
     }

--- a/Runtime/Public/State.cs
+++ b/Runtime/Public/State.cs
@@ -42,9 +42,9 @@ namespace Maze.StateFoundry
             return GetType().Name;
         }
 
-        public void Send<TEvent>(TEvent ev) where TEvent : struct, ITrigger
+        public void Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger
         {
-            OnEventSent?.Invoke(ev);
+            OnEventSent?.Invoke(trigger);
         }
 
         internal void InternalOnEnter()

--- a/Runtime/Public/Statechart.cs
+++ b/Runtime/Public/Statechart.cs
@@ -17,12 +17,12 @@ namespace Maze.StateFoundry
         }
 
 
-        public void Send<TEvent>(TEvent ev) where TEvent : struct, ITrigger
+        public void Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger
         {
-            m_runner.Send(ev);
+            m_runner.Send(trigger);
         }
 
-        public void Listen<TEvent>(Action<TEvent> callback) where TEvent : struct, ITrigger
+        public void Listen<TTrigger>(Action<TTrigger> callback) where TTrigger : struct, ITrigger
         {
             m_runner.Listen(callback);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Changes
Renames generic type parameters in the IGet interface to improve clarity and expressiveness:
- `TEvent` → `TTrigger`: Clarifies that the type represents the trigger causing the transition.
- `TState` → `TNextState`: Indicates that the type refers to the target state after the transition.

## Issues
- Resolves #18 