### PR TITLE
Add OpenUPM Hosting Reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "url": "https://github.com/MazeModels"
   },
   "license": "MIT",
+  "homepage": "https://openupm.com/packages/com.mazemodels.statefoundry/",
+  "bugs": {
+    "url": "https://github.com/MazeModels/StateFoundry/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MazeModels/StateFoundry.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Changes
Adds `OpenUPM` registry information to the package manifest to improve discoverability and installation convenience:
- Updates `package.json` to include a URL referencing the `OpenUPM` package registry.
- Makes it clear that the package is available on `OpenUPM`, facilitating usage for users relying on this platform.

## Issues
- Resolves #14 