### PR TITLE
Task/clarify api stability in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Thank you for your understanding and feedback as we continue to improve the pack
 ## Author and Licensing
 
 © 2025 Stefano Pittalis — All rights reserved.
-
-This project is **originally created and maintained by Stefano Pittalis**.
+_This project is originally created and maintained by Stefano Pittalis._
 
 ### License
 This repository is licensed under the **MIT License**.  

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Implementation of statecharts, a formalism for modeling stateful logic that exte
 
 ---
 
+## ⚠️ Unstable API Notice
+
+This package is currently in an **early prototyping phase** and is considered **unstable**. The API may change significantly without prior notice, which can lead to breaking changes and require adjustments in your projects.
+
+We recommend using the package with caution during this phase. The API is expected to stabilize with the release of version **v1.0.0**, at which point backward compatibility will be better maintained.
+
+Thank you for your understanding and feedback as we continue to improve the package.
+
+---
+
 ## Author and Licensing
 
 © 2025 Stefano Pittalis — All rights reserved.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Changes
Adds a clear notice to the `README` to inform users that the package is currently in an unstable prototyping phase.

# Issues
- Resolves #16 