### PR TITLE
Add OpenUPM Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,6 @@ Implementation of statecharts, a formalism for modeling stateful logic that exte
 
 ---
 
-## ⚠️ Unstable API Notice
-
-This package is currently in an **early prototyping phase** and is considered **unstable**. The API may change significantly without prior notice, which can lead to breaking changes and require adjustments in your projects.
-
-We recommend using the package with caution during this phase. The API is expected to stabilize with the release of version **v1.0.0**, at which point backward compatibility will be better maintained.
-
-Thank you for your understanding and feedback as we continue to improve the package.
-
----
-
 ## Installation via OpenUPM (Unity Package Manager)
 To make installing the package easier, you can use [OpenUPM](https://openupm.com/) an alternative registry for Unity’s Package Manager.
 
@@ -36,6 +26,16 @@ To make installing the package easier, you can use [OpenUPM](https://openupm.com
    - Click **Add package by name** (or similar, depending on your Unity version).
    - Enter the package name: `com.mazemodels.statefoundry`
    - Click **Add** to install the package into your project.
+
+---
+
+## Unstable API Notice
+
+This package is currently in an **early prototyping phase** and is considered **unstable**. The API may change significantly without prior notice, which can lead to breaking changes and require adjustments in your projects.
+
+We recommend using the package with caution during this phase. The API is expected to stabilize with the release of version **v1.0.0**, at which point backward compatibility will be better maintained.
+
+Thank you for your understanding and feedback as we continue to improve the package.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ Thank you for your understanding and feedback as we continue to improve the pack
 
 ---
 
+## Installation via OpenUPM (Unity Package Manager)
+To make installing the package easier, you can use [OpenUPM](https://openupm.com/) an alternative registry for Unity’s Package Manager.
+
+### Installation Steps:
+1. Add the OpenUPM registry to Unity:
+   - Open Unity and go to **Window > Package Manager**.
+   - Click the gear icon in the top right corner and select **Advanced Project Settings**.
+   - Under **Scoped Registries**, click **+** to add a new registry.
+   - Enter the following details:
+     - **Name:** OpenUPM
+     - **URL:** https://package.openupm.com
+     - **Scopes:** `com.mazemodels.statefoundry`
+
+2. Install the package:
+   - Return to the **Package Manager** window.
+   - Click **Add package by name** (or similar, depending on your Unity version).
+   - Enter the package name: `com.mazemodels.statefoundry`
+   - Click **Add** to install the package into your project.
+
+---
+
 ## Author and Licensing
 
 © 2025 Stefano Pittalis — All rights reserved.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Changes
Added a clear installation section to the `README` explaining how to install the package via OpenUPM.

It includes step-by-step instructions to add the `OpenUPM` registry in Unity’s Package Manager and how to install the `com.mazemodels.statefoundry` package.

## Issues
- Resolves #15 