### PR TITLE
Support Built-in State Callbacks

### DIFF
--- a/Runtime/Execution/StatechartEvents.cs
+++ b/Runtime/Execution/StatechartEvents.cs
@@ -28,9 +28,9 @@ namespace Maze.StateFoundry
             return SendRecurse(currentData, trigger);
         }
 
-        public void Listen<T>(Action<T> callback)
+        public void Listen<TTrigger>(Action<TTrigger> callback) where TTrigger : struct, ITrigger
         {
-            Type type = typeof(T);
+            Type type = typeof(TTrigger);
             if (m_callbacks.TryGetValue(type, out Delegate existing))
             {
                 m_callbacks[type] = Delegate.Combine(existing, callback);
@@ -40,6 +40,13 @@ namespace Maze.StateFoundry
                 m_callbacks[type] = callback;
             }
         }
+
+        public void OnLifecycleEvent<TState>(When expected, Action<TState> callback) where TState : State, new()
+        {
+            State state = EnsureStateIsRegistered<TState>();
+            state.OnLifecycleEvent += actual => OnLifecycleEvent(expected, actual, state, callback);
+        }
+
 
         StateData SendRecurse<TTrigger>(StateData data, TTrigger trigger) where TTrigger : struct, ITrigger
         {
@@ -104,6 +111,23 @@ namespace Maze.StateFoundry
             {
                 del.DynamicInvoke(output);
             }
+        }
+
+        void OnLifecycleEvent<TState>(When expected, When actual, State state, Action<TState> callback) where TState : State, new()
+        {
+            if (expected == actual)
+            {
+                callback?.Invoke(state as TState);
+            }
+        }
+
+        State EnsureStateIsRegistered<TState>() where TState : State, new()
+        {
+            if (!m_pool.States.TryGetValue(typeof(TState), out StateData data))
+            {
+                throw new ArgumentException($"State {typeof(TState).FullName} is not registered");
+            }
+            return data.State;
         }
     }
 }

--- a/Runtime/Execution/StatechartRunner.cs
+++ b/Runtime/Execution/StatechartRunner.cs
@@ -24,6 +24,7 @@ namespace Maze.StateFoundry
             m_pool.Dispose();
         }
 
+
         public void Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger
         {
             LogEventSent<TTrigger>();
@@ -46,6 +47,28 @@ namespace Maze.StateFoundry
                 callback?.Invoke(output);
             });
         }
+
+
+        public void OnEnter<TState>(Action<TState> callback) where TState : State, new()
+        {
+            m_events.OnLifecycleEvent(When.OnEnter, callback);
+        }
+
+        public void OnExit<TState>(Action<TState> callback) where TState : State, new()
+        {
+            m_events.OnLifecycleEvent(When.OnExit, callback);
+        }
+
+        public void OnCreate<TState>(Action<TState> callback) where TState : State, new()
+        {
+            m_events.OnLifecycleEvent(When.OnCreate, callback);
+        }
+
+        public void OnDispose<TState>(Action<TState> callback) where TState : State, new()
+        {
+            m_events.OnLifecycleEvent(When.OnDispose, callback);
+        }
+
 
         void SubscribeToEvents()
         {

--- a/Runtime/Public/State.cs
+++ b/Runtime/Public/State.cs
@@ -6,6 +6,7 @@ namespace Maze.StateFoundry
     public abstract class State : IDisposable
     {
         internal event Action<ITrigger> OnEventSent;
+        internal event Action<When> OnLifecycleEvent;
 
         public State()
         {
@@ -51,24 +52,28 @@ namespace Maze.StateFoundry
         {
             LogSpecialMethod(nameof(OnEnter));
             OnEnter();
+            OnLifecycleEvent?.Invoke(When.OnEnter);
         }
 
         internal void InternalOnExit()
         {
             LogSpecialMethod(nameof(OnExit));
             OnExit();
+            OnLifecycleEvent?.Invoke(When.OnExit);
         }
 
         internal void InternalOnCreate()
         {
             LogSpecialMethod(nameof(OnCreate));
             OnCreate();
+            OnLifecycleEvent?.Invoke(When.OnCreate);
         }
 
         internal void InternalOnDispose()
         {
             LogSpecialMethod(nameof(OnDispose));
             OnDispose();
+            OnLifecycleEvent?.Invoke(When.OnDispose);
         }
 
         void LogSpecialMethod(string methodName)

--- a/Runtime/Public/Statechart.cs
+++ b/Runtime/Public/Statechart.cs
@@ -26,5 +26,26 @@ namespace Maze.StateFoundry
         {
             m_runner.Listen(callback);
         }
+
+
+        public void OnEnter<TState>(Action<TState> callback) where TState : State, new()
+        {
+            m_runner.OnEnter(callback);
+        }
+
+        public void OnExit<TState>(Action<TState> callback) where TState : State, new()
+        {
+            m_runner.OnExit(callback);
+        }
+
+        public void OnCreate<TState>(Action<TState> callback) where TState : State, new()
+        {
+            m_runner.OnCreate(callback);
+        }
+
+        public void OnDispose<TState>(Action<TState> callback) where TState : State, new()
+        {
+            m_runner.OnDispose(callback);
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Summary
- Introduces a mechanism for listening to `State` lifecycle events (`OnEnter`, `OnExit`, `OnCreate`, `OnDispose`) without requiring boilerplate code inside each state.
- Fully backward compatible. No changes required for existing state definitions or consumers.

## Issues
Closes #17 
