### PR TITLE
Enable Auto-Referenced on Assembly Definition

### DIFF
--- a/Runtime/Maze.StateFoundry.asmdef
+++ b/Runtime/Maze.StateFoundry.asmdef
@@ -7,7 +7,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Summary
The `Auto Referenced` flag for the `Maze.StateFoundry` assembly definition has been set to `true`.

With this change, the assembly will be automatically included in other parts of the project without requiring manual reference configuration. 

This simplifies the initial setup, especially for users unfamiliar with Unity's assembly definition system, and reduces potential friction when getting started.

## Issues
- Closes #34 