### PR TITLE
Shared Event World for Statecharts

### DIFF
--- a/Runtime/Execution/ITriggerSink.cs
+++ b/Runtime/Execution/ITriggerSink.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Maze.StateFoundry
+{
+    interface ITriggerSink
+    {
+        event Action<ITrigger> OnTrigger;
+    }
+}

--- a/Runtime/Execution/ITriggerSink.cs.meta
+++ b/Runtime/Execution/ITriggerSink.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9c87072333e94ff2bc4470d0ab184663
+timeCreated: 1749054300

--- a/Runtime/Execution/StatechartRunner.cs
+++ b/Runtime/Execution/StatechartRunner.cs
@@ -4,8 +4,10 @@ using UnityEngine;
 
 namespace Maze.StateFoundry
 {
-    sealed class StatechartRunner<TInitialState> : IDisposable where TInitialState : State, new()
+    sealed class StatechartRunner<TInitialState> : IStatechart, ITriggerSink, IDisposable where TInitialState : State, new()
     {
+        public event Action<ITrigger> OnTrigger;
+
         readonly Type m_statechartType;
         readonly StatePool<TInitialState> m_pool;
         readonly StatechartEvents<TInitialState> m_events;
@@ -73,7 +75,7 @@ namespace Maze.StateFoundry
         {
             foreach (StateData data in m_pool.States.Values)
             {
-                data.State.OnEventSent += OnSend;
+                data.State.OnEventSent += InternalSend;
             }
         }
 
@@ -81,15 +83,16 @@ namespace Maze.StateFoundry
         {
             foreach (StateData data in m_pool.States.Values)
             {
-                data.State.OnEventSent -= OnSend;
+                data.State.OnEventSent -= InternalSend;
             }
         }
 
-        void OnSend(ITrigger trigger)
+        void InternalSend(ITrigger trigger)
         {
             MethodInfo method = GetType().GetMethod(nameof(Send));
             MethodInfo genericMethod = method?.MakeGenericMethod(trigger.GetType());
             genericMethod?.Invoke(this, new object[] { trigger });
+            OnTrigger?.Invoke(trigger);
         }
 
         void LogTransition(StateData oldData, StateData newData, ITrigger trigger)

--- a/Runtime/Execution/StatechartRunner.cs
+++ b/Runtime/Execution/StatechartRunner.cs
@@ -27,7 +27,6 @@ namespace Maze.StateFoundry
 
         public void Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger
         {
-            LogEventSent<TTrigger>();
             StateData newData = m_events.Send(trigger);
 
             if (newData == null)
@@ -35,7 +34,7 @@ namespace Maze.StateFoundry
                 return;
             }
 
-            LogTransition(m_pool.CurrentData, newData);
+            LogTransition(m_pool.CurrentData, newData, trigger);
             m_pool.SetCurrentState(newData);
         }
 
@@ -93,19 +92,14 @@ namespace Maze.StateFoundry
             genericMethod?.Invoke(this, new object[] { trigger });
         }
 
-        void LogEventSent<TTrigger>() where TTrigger : struct, ITrigger
+        void LogTransition(StateData oldData, StateData newData, ITrigger trigger)
         {
-            Debug.Log($"<color=yellow>[S]|{m_statechartType.Name}|: {typeof(TTrigger).Name}</color>");
-        }
-
-        static void LogTransition(StateData oldData, StateData newData)
-        {
-            Debug.Log($"<color=cyan>[T]: |{oldData}| => |{newData}|</color>");
+            Debug.Log($"<color=cyan>{{R}}|[{m_statechartType.Name}]: [{oldData}] --{trigger.GetType().Name}--> [{newData}]</color>");
         }
 
         void LogEventReceived<TTrigger>() where TTrigger : struct, ITrigger
         {
-            Debug.Log($"<color=magenta>[R]|{m_statechartType.Name}|: {typeof(TTrigger).Name}</color>");
+            Debug.Log($"<color=magenta>{{R}}|{m_statechartType.Name}|: {typeof(TTrigger).Name}</color>");
         }
     }
 }

--- a/Runtime/Execution/StatechartWorld.cs
+++ b/Runtime/Execution/StatechartWorld.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Maze.StateFoundry
+{
+    sealed class StatechartWorld : IStatechart, IDisposable
+    {
+        readonly HashSet<IStatechart> m_charts;
+        readonly Dictionary<ITriggerSink, Action<ITrigger>> m_callbacks;
+
+        public StatechartWorld(IList<IStatechart> charts)
+        {
+            m_charts = new HashSet<IStatechart>(charts);
+            m_callbacks = new Dictionary<ITriggerSink, Action<ITrigger>>();
+            SubscribeToTriggers();
+        }
+
+        public void Dispose()
+        {
+            UnsubscribeToTriggers();
+        }
+
+        public void Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger
+        {
+            foreach (IStatechart statechart in m_charts)
+            {
+                statechart.Send(trigger);
+            }
+        }
+
+        public void Listen<TTrigger>(Action<TTrigger> callback) where TTrigger : struct, ITrigger
+        {
+            foreach (IStatechart statechart in m_charts)
+            {
+                statechart.Listen(callback);
+            }
+        }
+
+        public void OnEnter<TState>(Action<TState> callback) where TState : State, new()
+        {
+            foreach (IStatechart statechart in m_charts)
+            {
+                statechart.OnEnter(callback);
+            }
+        }
+
+        public void OnExit<TState>(Action<TState> callback) where TState : State, new()
+        {
+            foreach (IStatechart statechart in m_charts)
+            {
+                statechart.OnExit(callback);
+            }
+        }
+
+        public void OnCreate<TState>(Action<TState> callback) where TState : State, new()
+        {
+            foreach (IStatechart statechart in m_charts)
+            {
+                statechart.OnCreate(callback);
+            }
+        }
+
+        public void OnDispose<TState>(Action<TState> callback) where TState : State, new()
+        {
+            foreach (IStatechart statechart in m_charts)
+            {
+                statechart.OnDispose(callback);
+            }
+        }
+
+        void SubscribeToTriggers()
+        {
+            foreach (IStatechart chart in m_charts)
+            {
+                ITriggerSink sink = GetSink(chart);
+                m_callbacks[sink] = trigger => OnInternalTrigger(trigger, chart);
+                sink.OnTrigger += m_callbacks[sink];
+            }
+        }
+
+        void UnsubscribeToTriggers()
+        {
+            foreach (KeyValuePair<ITriggerSink, Action<ITrigger>> kvp in m_callbacks)
+            {
+                kvp.Key.OnTrigger -= kvp.Value;
+            }
+        }
+
+        static ITriggerSink GetSink(IStatechart statechart)
+        {
+            Type type = statechart.GetType();
+            FieldInfo runnerField = type.GetField("Runner", BindingFlags.NonPublic | BindingFlags.Instance);
+            return runnerField?.GetValue(statechart) as ITriggerSink;
+        }
+
+        void OnInternalTrigger(ITrigger trigger, IStatechart chart)
+        {
+            foreach (IStatechart statechart in m_charts)
+            {
+                if (statechart == chart)
+                {
+                    continue;
+                }
+
+                MethodInfo method = statechart.GetType().GetMethod(nameof(Send));
+                MethodInfo genericMethod = method?.MakeGenericMethod(trigger.GetType());
+                genericMethod?.Invoke(statechart, new object[] { trigger });
+            }
+        }
+    }
+}

--- a/Runtime/Execution/StatechartWorld.cs.meta
+++ b/Runtime/Execution/StatechartWorld.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3f372df17a614a47bb2f6e86897a0244
+timeCreated: 1749048823

--- a/Runtime/Public/Interfaces/IStatechart.cs
+++ b/Runtime/Public/Interfaces/IStatechart.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Maze.StateFoundry
+{
+    public interface IStatechart
+    {
+        public void Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger;
+        public void Listen<TTrigger>(Action<TTrigger> callback) where TTrigger : struct, ITrigger;
+        
+        public void OnEnter<TState>(Action<TState> callback) where TState : State, new();
+        public void OnExit<TState>(Action<TState> callback) where TState : State, new();
+        public void OnCreate<TState>(Action<TState> callback) where TState : State, new();
+        public void OnDispose<TState>(Action<TState> callback) where TState : State, new();
+    }
+}

--- a/Runtime/Public/Interfaces/IStatechart.cs.meta
+++ b/Runtime/Public/Interfaces/IStatechart.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9d4d64cbeeb7468e8387e45bfd9b1ab0
+timeCreated: 1749048471

--- a/Runtime/Public/State.cs
+++ b/Runtime/Public/State.cs
@@ -78,7 +78,8 @@ namespace Maze.StateFoundry
 
         void LogSpecialMethod(string methodName)
         {
-            Debug.Log($"{ToString()}: {methodName}");
+            // TODO: Implement verbosity toggle
+            // Debug.Log($"{ToString()}: {methodName}");
         }
     }
 }

--- a/Runtime/Public/Stateworld.cs
+++ b/Runtime/Public/Stateworld.cs
@@ -1,51 +1,49 @@
-using System;
+﻿using System;
 
 namespace Maze.StateFoundry
 {
-    public abstract class Statechart<TInitialState> : IStatechart, IDisposable where TInitialState : State, new()
+    public sealed class Stateworld : IStatechart, IDisposable
     {
-        internal readonly StatechartRunner<TInitialState> Runner;
+        readonly StatechartWorld m_internal;
 
-        public Statechart()
+        public Stateworld(params IStatechart[] charts)
         {
-            Runner = new StatechartRunner<TInitialState>(GetType());
+            m_internal = new StatechartWorld(charts);
         }
-
+        
         public void Dispose()
         {
-            Runner.Dispose();
+            m_internal.Dispose();
         }
-
 
         public void Send<TTrigger>(TTrigger trigger) where TTrigger : struct, ITrigger
         {
-            Runner.Send(trigger);
+            m_internal.Send(trigger);
         }
 
         public void Listen<TTrigger>(Action<TTrigger> callback) where TTrigger : struct, ITrigger
         {
-            Runner.Listen(callback);
+            m_internal.Listen(callback);
         }
-
 
         public void OnEnter<TState>(Action<TState> callback) where TState : State, new()
         {
-            Runner.OnEnter(callback);
+            m_internal.OnEnter(callback);
         }
 
         public void OnExit<TState>(Action<TState> callback) where TState : State, new()
         {
-            Runner.OnExit(callback);
+            m_internal.OnExit(callback);
         }
 
         public void OnCreate<TState>(Action<TState> callback) where TState : State, new()
         {
-            Runner.OnCreate(callback);
+            m_internal.OnCreate(callback);
         }
 
         public void OnDispose<TState>(Action<TState> callback) where TState : State, new()
         {
-            Runner.OnDispose(callback);
+            m_internal.OnDispose(callback);
         }
     }
 }

--- a/Runtime/Public/Stateworld.cs.meta
+++ b/Runtime/Public/Stateworld.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f18a476ec64e49d4912abd728c241ff8


### PR DESCRIPTION
# Summary
A new mechanism has been implemented to allow multiple statechart instances to coexist within a shared context where events are globally broadcast. This aims to simplify communication between charts by removing the need for a dedicated broker to manually forward events.

## Issues
- Closes #8