### PR TITLE
Refresh Asset After On-Demand Graph Generation

### DIFF
--- a/Editor/UmlGeneration/Editor/DrawStatechart.cs
+++ b/Editor/UmlGeneration/Editor/DrawStatechart.cs
@@ -1,5 +1,7 @@
+using System;
+using System.IO;
 using UnityEditor;
-using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Maze.StateFoundry.Editor
 {
@@ -30,6 +32,46 @@ namespace Maze.StateFoundry.Editor
             {
                 string path = AssetDatabase.GetAssetPath(obj);
                 installer.Run(path);
+                ImportNewAsset(path);
+            }
+        }
+
+        static void ImportNewAsset(string pathToScript)
+        {
+            if (TryGetNewAsset(pathToScript, out string pathToAsset))
+            {
+                AssetDatabase.ImportAsset(pathToAsset);
+            }
+        }
+
+        static bool TryGetNewAsset(string pathToScript, out string pathToAsset)
+        {
+            if (string.IsNullOrEmpty(pathToScript))
+            {
+                pathToAsset = null;
+                return false;
+            }
+
+            if (!TryGetAssetNameNoThrow(pathToScript, out pathToAsset))
+            {
+                return false;
+            }
+
+            pathToAsset = Path.Combine(Path.GetDirectoryName(pathToScript), pathToAsset);
+            return true;
+        }
+
+        static bool TryGetAssetNameNoThrow(string pathToScript, out string pathToAsset)
+        {
+            try
+            {
+                pathToAsset = $"{Path.GetFileNameWithoutExtension(pathToScript)}{UmlPrinter.FILE_EXTENSION}";
+                return true;
+            }
+            catch (Exception)
+            {
+                pathToAsset = null;
+                return false;
             }
         }
     }

--- a/Editor/UmlGeneration/Service/UmlPrinter/UmlPrinter.cs
+++ b/Editor/UmlGeneration/Service/UmlPrinter/UmlPrinter.cs
@@ -6,7 +6,7 @@ namespace Maze.StateFoundry.Editor
 {
     sealed class UmlPrinter
     {
-        const string FILE_EXTENSION = ".g.puml";
+        public const string FILE_EXTENSION = ".g.puml";
 
         readonly BlockFinder m_finder;
         readonly TextGenerator m_textGenerator;

--- a/Editor/UmlGeneration/Statechart/GraphBlock.g.puml
+++ b/Editor/UmlGeneration/Statechart/GraphBlock.g.puml
@@ -25,11 +25,5 @@ Maze_StateFoundry_Editor_GraphBlock_Error --> Maze_StateFoundry_Editor_GraphBloc
 Maze_StateFoundry_Editor_GraphBlock_Update_Generation_HierarchyAnalysis --> Maze_StateFoundry_Editor_GraphBlock_Update_Generation_TextGeneration : HierarchyAnalyzed
 Maze_StateFoundry_Editor_GraphBlock_Update_Generation_TextGeneration --> Maze_StateFoundry_Editor_GraphBlock_Update_Generation_UmlPrinting : TextGenerated
 Maze_StateFoundry_Editor_GraphBlock_Update_Generation_UmlPrinting --> Maze_StateFoundry_Editor_GraphBlock_Idle : UmlPrinted
-Maze_StateFoundry_Editor_GraphBlock_Idle : OnEnter() → Ready
-Maze_StateFoundry_Editor_GraphBlock_Update_BlockEvaluation : OnEnter() → CheckIfBlock
-Maze_StateFoundry_Editor_GraphBlock_Error : OnEnter() → RaiseError
-Maze_StateFoundry_Editor_GraphBlock_Update_Generation_HierarchyAnalysis : OnEnter() → AnalyzeHierarchy
-Maze_StateFoundry_Editor_GraphBlock_Update_Generation_TextGeneration : OnEnter() → GenerateText
-Maze_StateFoundry_Editor_GraphBlock_Update_Generation_UmlPrinting : OnEnter() → PrintUml
 [*] --> Maze_StateFoundry_Editor_GraphBlock_Idle
 @enduml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Summary
Fixes an issue where newly generated assets were not recognized by the Unity editor after on-demand graph generation. Unity was not automatically notified of the new file, resulting in the asset not appearing in the project view.

## Misc
- Updated GraphBlock diagram.

## Issue
- Fixes #37 