### PR TITLE
Broaden Scoped Registry Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To make installing the package easier, you can use [OpenUPM](https://openupm.com
    - Enter the following details:
      - **Name:** OpenUPM
      - **URL:** https://package.openupm.com
-     - **Scopes:** `com.mazemodels.statefoundry`
+     - **Scopes:** `com.mazemodels`
 
 2. Install the package:
    - Return to the **Package Manager** window.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Summary
Updates the scoped registry configuration to use a broader namespace: `com.mazemodels.statefoundry` -> `com.mazemodels`

## Issue
- Fixes #48