### PR TITLE
Separate CodeRabbit badge from description line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # StateFoundry
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/MazeModels/StateFoundry?utm_source=oss&utm_medium=github&utm_campaign=MazeModels%2FStateFoundry&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+
 Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.
 
 ## Additional resources

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.statefoundry",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "displayName": "State Foundry",
   "description": "Implementation of statecharts, a formalism for modeling stateful logic that extends traditional finite state machines.",
   "hideInEditor": false,


### PR DESCRIPTION
# Summary
- Adjuste the README so that the CodeRabbit badge is followed by a line break.
## Issue
- Fixes #53 